### PR TITLE
Label image to let it appear in the payload

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -5,5 +5,5 @@ RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o bin/manager .
 
 FROM registry.ci.openshift.org/ocp/4.15:base-rhel9
 COPY --from=builder /go/src/github.com/metal3-io/cluster-api-provider-metal3/bin/manager /
-
+LABEL io.openshift.release.operator=true
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
The image is labelled as `for_payload: true` in [ART's config](https://github.com/openshift-eng/ocp-build-data/blob/openshift-4.15/images/ose-baremetal-cluster-api-controllers.yml#L19), but does not have the required label nor incoming references from a payload image. Hence, it's currently not being included in the payload by default.
Setting the `io.openshift.release.operator` label to true should fix this