### PR TITLE
OCPBUGS-86476: Adopt existing Metal3 Remediation CRDs on upgrade

### DIFF
--- a/openshift/capi-operator-manifests/default/manifests.yaml
+++ b/openshift/capi-operator-manifests/default/manifests.yaml
@@ -5820,6 +5820,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    capi-operator.openshift.io/adopt-existing: always
     controller-gen.kubebuilder.io/version: v0.18.0
     service.beta.openshift.io/inject-cabundle: "true"
   labels:
@@ -6027,6 +6028,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    capi-operator.openshift.io/adopt-existing: always
     controller-gen.kubebuilder.io/version: v0.18.0
     service.beta.openshift.io/inject-cabundle: "true"
   labels:

--- a/openshift/kustomization.yaml
+++ b/openshift/kustomization.yaml
@@ -57,7 +57,19 @@ patches:
     version: v1
     kind: CustomResourceDefinition
     name: metal3remediations.infrastructure.cluster.x-k8s.io
+- path: ./patches/remediation-crd-adopt-existing.yaml
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: metal3remediations.infrastructure.cluster.x-k8s.io
 - path: ./patches/crd-storage-version.yaml
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: metal3remediationtemplates.infrastructure.cluster.x-k8s.io
+- path: ./patches/remediation-crd-adopt-existing.yaml
   target:
     group: apiextensions.k8s.io
     version: v1

--- a/openshift/patches/remediation-crd-adopt-existing.yaml
+++ b/openshift/patches/remediation-crd-adopt-existing.yaml
@@ -1,0 +1,16 @@
+# Add the adopt-existing annotation to Metal3 Remediation CRDs.
+#
+# On Default clusters (ClusterAPIMachineManagementBareMetal feature gate off),
+# CVO deploys these CRDs via openshift/manifests/. When the
+# ClusterAPIMachineManagementBareMetal feature gate is enabled, the
+# cluster-capi-operator becomes responsible for managing them instead.
+# This annotation allows the operator to adopt the pre-existing CRDs
+# without being blocked by boxcutter's collision protection.
+#
+# Targets (specified in kustomization.yaml):
+#   - metal3remediations.infrastructure.cluster.x-k8s.io
+#   - metal3remediationtemplates.infrastructure.cluster.x-k8s.io
+
+- op: add
+  path: /metadata/annotations/capi-operator.openshift.io~1adopt-existing
+  value: "always"


### PR DESCRIPTION
## Summary

- On Default clusters (`ClusterAPIMachineManagementBareMetal` feature gate off), CVO deploys the Metal3 Remediation CRDs via `openshift/manifests/`.
- When the `ClusterAPIMachineManagementBareMetal` feature gate is enabled, the cluster-capi-operator becomes responsible for managing them instead.
- Without the `adopt-existing` annotation, boxcutter's collision protection blocks the entire CAPM3 deployment (including the `capm3-controller-manager` Deployment and `capm3-webhook-service` Service) until the collisions are resolved, leaving the CRDs with conversion webhook config pointing at a non-existent service.
- This adds `capi-operator.openshift.io/adopt-existing: always` to the `metal3remediations` and `metal3remediationtemplates` CRDs, following the same pattern as https://github.com/openshift/cluster-api/pull/274 for IPAM CRDs.

Uses support added in https://github.com/openshift/cluster-capi-operator/pull/514

## Test plan

- [x] Deploy on a bare metal cluster with `ClusterAPIMachineManagementBareMetal` enabled
- [x] Verify `capm3-controller-manager` deployment is created without collision delays
- [x] Verify the conversion webhook service is available immediately
- [x] Verify namespace deletion works (no stuck `Terminating` state due to missing webhook)