### PR TITLE
🐛 OCPBUGS-85337: set imagePullPolicy IfNotPresent on provider workloads

### DIFF
--- a/openshift/tools/go.mod
+++ b/openshift/tools/go.mod
@@ -3,7 +3,7 @@ module tools
 go 1.25.0
 
 require (
-	github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c
+	github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260703150646-e8d2830a6f46
 	sigs.k8s.io/kustomize/kustomize/v5 v5.8.1
 )
 

--- a/openshift/tools/go.sum
+++ b/openshift/tools/go.sum
@@ -101,8 +101,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80 h1:r0S/yoZAI0iWo1JvoIijaIgWGWf/izg4WiV7Wrtz16k=
 github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
-github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c h1:mCbdsqRsXvIw22zy5c07zmFpaE/ng6ehx0Pq399UM3w=
-github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c/go.mod h1:mRpBhhCeqkf0GwRIVYfwlZlTqOMRfxMLxxFmltzMksY=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260703150646-e8d2830a6f46 h1:ZZHWNeS9h8Wmnny6j4VJbxsrwkJmuN3GqUoaw4n/8Cw=
+github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260703150646-e8d2830a6f46/go.mod h1:mRpBhhCeqkf0GwRIVYfwlZlTqOMRfxMLxxFmltzMksY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/kustomization.yaml
+++ b/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Component
 namespace: openshift-cluster-api
 
 resources:
-  - webhook-namespace-selector.yaml
+  - kustomize-values.yaml
 
 # Scope all provider webhooks to the openshift-cluster-api namespace.
 # This prevents webhooks from intercepting requests in other namespaces,
@@ -12,7 +12,7 @@ resources:
 replacements:
   - source:
       kind: ConfigMap
-      name: webhook-namespace-selector
+      name: kustomize-values
       fieldPath: data.namespace
     targets:
       - select:
@@ -25,6 +25,56 @@ replacements:
           kind: MutatingWebhookConfiguration
         fieldPaths:
           - webhooks.*.namespaceSelector.matchLabels.kubernetes\.io/metadata\.name
+        options:
+          create: true
+  # In disconnected clusters using pinned image sets, images are already
+  # present on nodes. IfNotPresent avoids unnecessary pulls that fail
+  # when the registry is unreachable (OCPBUGS-85337).
+  - source:
+      kind: ConfigMap
+      name: kustomize-values
+      fieldPath: data.imagePullPolicy
+    targets:
+      - select:
+          kind: Deployment
+        fieldPaths:
+          - spec.template.spec.containers.*.imagePullPolicy
+        options:
+          create: true
+      - select:
+          kind: StatefulSet
+        fieldPaths:
+          - spec.template.spec.containers.*.imagePullPolicy
+        options:
+          create: true
+      - select:
+          kind: DaemonSet
+        fieldPaths:
+          - spec.template.spec.containers.*.imagePullPolicy
+        options:
+          create: true
+      - select:
+          kind: ReplicaSet
+        fieldPaths:
+          - spec.template.spec.containers.*.imagePullPolicy
+        options:
+          create: true
+      - select:
+          kind: Job
+        fieldPaths:
+          - spec.template.spec.containers.*.imagePullPolicy
+        options:
+          create: true
+      - select:
+          kind: CronJob
+        fieldPaths:
+          - spec.jobTemplate.spec.template.spec.containers.*.imagePullPolicy
+        options:
+          create: true
+      - select:
+          kind: Pod
+        fieldPaths:
+          - spec.containers.*.imagePullPolicy
         options:
           create: true
 

--- a/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/kustomize-values.yaml
+++ b/openshift/tools/vendor/github.com/openshift/cluster-capi-operator/manifests-gen/kustomize-values.yaml
@@ -1,14 +1,15 @@
 # This ConfigMap is a kustomize workaround: replacements need a concrete source resource
-# to read a value from, but there is no real resource that holds the target namespace.
-# This ConfigMap acts as that source, providing the namespace value to inject into webhook
-# namespaceSelector fields via the replacements defined in kustomization.yaml.
+# to read a value from, but there is no real resource that holds the values we need.
+# This ConfigMap acts as that source, providing values to inject into target resources
+# via the replacements defined in kustomization.yaml.
 # It is marked as local-config so kustomize never emits it in the final output.
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: webhook-namespace-selector
+  name: kustomize-values
   annotations:
     # Marks this resource as local-only so kustomize excludes it from the final output.
     config.kubernetes.io/local-config: "true"
 data:
   namespace: openshift-cluster-api
+  imagePullPolicy: IfNotPresent

--- a/openshift/tools/vendor/modules.txt
+++ b/openshift/tools/vendor/modules.txt
@@ -114,7 +114,7 @@ github.com/opencontainers/go-digest
 # github.com/openshift/api v0.0.0-20260416105050-3c6b218b8a80
 ## explicit; go 1.25.0
 github.com/openshift/api/config/v1
-# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260506082208-390a5b10a37c
+# github.com/openshift/cluster-capi-operator/manifests-gen v0.0.0-20260703150646-e8d2830a6f46
 ## explicit; go 1.25.0
 github.com/openshift/cluster-capi-operator/manifests-gen
 github.com/openshift/cluster-capi-operator/manifests-gen/providermetadata


### PR DESCRIPTION
## Summary

- Vendors the `manifests-gen` fix from openshift/cluster-capi-operator#618.
- The `capm3-controller-manager` Deployment already had `imagePullPolicy: IfNotPresent`, so regenerated manifests are unchanged.
- The vendored kustomize component now enforces `IfNotPresent` on all workload types (Deployment, StatefulSet, DaemonSet, etc.), ensuring it cannot regress.

Depends on: https://github.com/openshift/cluster-capi-operator/pull/618 (merged)

Port of: https://github.com/openshift/cluster-api-provider-aws/pull/619

## Test plan

- [ ] Run upgrade in a techpreview disconnected cluster using only pinned image sets and verify `capm3-controller-manager` pods do not crash with `ImagePullBackOff`
- [ ] Verify `capm3-controller-manager` Deployment has `imagePullPolicy: IfNotPresent`