### PR TITLE
OCPBUGS-98329: Grant capi-installer permission on ConfigMap

### DIFF
--- a/openshift/manifests/0000_30_cluster-api-provider-metal3_00_capi-installer-rbac.yaml
+++ b/openshift/manifests/0000_30_cluster-api-provider-metal3_00_capi-installer-rbac.yaml
@@ -1,0 +1,29 @@
+---
+# Grants the Cluster API installer SA the cluster-wide permissions needed to
+# manage the ConfigMap resource included in the metal3 provider manifests.
+# Aggregates into openshift-capi-installer:provider-permissions via the
+# capi-operator.openshift.io/aggregate-to-installer label.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/feature-gate: "ClusterAPIMachineManagementBareMetal"
+  labels:
+    capi-operator.openshift.io/aggregate-to-installer: "true"
+  name: openshift-capi-installer:metal3
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete


### PR DESCRIPTION
Requires https://github.com/openshift/cluster-capi-operator/pull/623 to be functional.
