### PR TITLE
OCPBUGS-98542: Remove dangling symlink

### DIFF
--- a/openshift/Dockerfile.openshift
+++ b/openshift/Dockerfile.openshift
@@ -1,1 +1,12 @@
-../Dockerfile.ocp
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
+WORKDIR /go/src/github.com/metal3-io/cluster-api-provider-metal3
+COPY . .
+RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o bin/manager .
+
+FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
+COPY --from=builder /go/src/github.com/metal3-io/cluster-api-provider-metal3/bin/manager /
+COPY --from=builder /go/src/github.com/metal3-io/cluster-api-provider-metal3/openshift/manifests /manifests
+
+ENTRYPOINT ["/manager"]
+
+LABEL io.openshift.release.operator true


### PR DESCRIPTION
Replace openshift/Dockerfile.openshift symlink with a regular file copy of Dockerfile.ocp.

This mitigates path traversal / zip-slip
vulnerabilities (CWE-59 / CWE-22). See OCPBUGS-65
for a verified RCE exploit where unvalidated symlinks allowed arbitrary command execution. Konflux enforces this as part of SLSA supply-chain security.